### PR TITLE
[ISSUE-16]Strips the source file path from css parameter when constructing html reference

### DIFF
--- a/luadox/render/html.py
+++ b/luadox/render/html.py
@@ -285,6 +285,8 @@ class HTMLRenderer(Renderer):
 
         css = self.config.get('project', 'css', fallback=None)
         if css:
+            # The stylesheet is always copied to doc root, so take only the filename
+            _, css = os.path.split(css)
             head.append('<link href="{}{}?{}" rel="stylesheet" />'.format(root, css, self._assets_version))
 
         favicon = self.config.get('project', 'favicon', fallback=None)


### PR DESCRIPTION
Refer to [ISSUE-16](https://github.com/jtackaberry/luadox/issues/16)

@jtackaberry Could you please review and consider this change for inclusion in main repo.
